### PR TITLE
[BISERVER-13407]-BISERVER-13407 ValidationQuery and Pooling options not sent to DB when datasource is defined in Manage DataSources Perspective

### DIFF
--- a/src/main/java/org/pentaho/commons/connection/IPentahoConnection.java
+++ b/src/main/java/org/pentaho/commons/connection/IPentahoConnection.java
@@ -84,6 +84,11 @@ public interface IPentahoConnection {
   public static final String CONNECTION = "connection"; //$NON-NLS-1$
 
   /**
+   * Standard key to use for a connection's name property.
+   */
+  public static final String CONNECTION_NAME = "connection_name"; //$NON-NLS-1$
+
+  /**
    * Standard key to use for a provider property.
    */
   public static final String PROVIDER = "provider"; //$NON-NLS-1$


### PR DESCRIPTION
 - added new constant CONNECTION_NAME