### PR TITLE
fix(ci): restore separate setup-maven-settings job for proper volume …

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -29,8 +29,29 @@ env:
   ACTUAL_RELEASE: ${{ inputs.actualRelease || 'false' }}
 
 jobs:
+  setup-maven-settings:
+    name: Setup Maven settings
+    runs-on: [orl-lab]
+    container:
+      image: ${{ vars.ARTIFACTORY_HOST }}/devops-docker-release/pentaho/actions-common:jdk21-20250717.225
+      credentials:
+        username: ${{ secrets.PENTAHO_CICD_ONE_USER }}
+        password: ${{ secrets.PENTAHO_CICD_ONE_KEY }}
+      volumes:
+        - /home/runner/caches/pentaho/.m2:/root/.m2
+    steps:
+      - name: Retrieve settings file
+        id: common-maven
+        uses: pentaho/actions-common@stable
+
+      - name: Copy settings.xml to .m2 directory
+        shell: sh
+        run: |
+          cp "${{ steps.common-maven.outputs.settings-file-path }}" /root/.m2
+
   deploy-release-candidate:
     name: Deploy Release Candidate
+    needs: setup-maven-settings
     runs-on: [orl-lab]
     container:
       image: ${{ vars.ARTIFACTORY_HOST }}/devops-docker-release/pentaho/actions-common:jdk21-20250717.225
@@ -50,15 +71,6 @@ jobs:
       SONAR_TOKEN: ${{ secrets.WINGMAN_SONAR_TOKEN }}
 
     steps:
-      - name: Retrieve settings file
-        id: common-maven
-        uses: pentaho/actions-common@stable
-
-      - name: Setup Maven settings
-        shell: sh
-        run: |
-          cp "${{ steps.common-maven.outputs.settings-file-path }}" /root/.m2
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,8 +29,29 @@ jobs:
           checkAllCommitMessages: "true"
           accessToken: ${{ secrets.GITHUB_TOKEN }}
 
+  setup-maven-settings:
+    name: Setup Maven settings
+    runs-on: [orl-lab]
+    container:
+      image: ${{ vars.ARTIFACTORY_HOST }}/devops-docker-release/pentaho/actions-common:jdk21-20250717.225
+      credentials:
+        username: ${{ secrets.PENTAHO_CICD_ONE_USER }}
+        password: ${{ secrets.PENTAHO_CICD_ONE_KEY }}
+      volumes:
+        - /home/runner/caches/pentaho/.m2:/root/.m2
+    steps:
+      - name: Retrieve settings file
+        id: common-maven
+        uses: pentaho/actions-common@stable
+
+      - name: Copy settings.xml to .m2 directory
+        shell: sh
+        run: |
+          cp "${{ steps.common-maven.outputs.settings-file-path }}" /root/.m2
+
   build-and-test:
     name: Build & Test
+    needs: setup-maven-settings
     runs-on: [orl-lab]
     permissions:
       statuses: write
@@ -53,15 +74,6 @@ jobs:
       SONAR_TOKEN: ${{ secrets.WINGMAN_SONAR_TOKEN }}
 
     steps:
-      - name: Retrieve settings file
-        id: common-maven
-        uses: pentaho/actions-common@stable
-
-      - name: Setup Maven settings
-        shell: sh
-        run: |
-          cp "${{ steps.common-maven.outputs.settings-file-path }}" /root/.m2
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,15 +43,6 @@ jobs:
         - /home/runner/caches/pentaho/.m2:/root/.m2
 
     steps:
-      - name: Retrieve settings file
-        id: common-maven
-        uses: pentaho/actions-common@stable
-
-      - name: Copy settings.xml to .m2 directory
-        shell: sh
-        run: |
-          cp "${{ steps.common-maven.outputs.settings-file-path }}" /root/.m2
-
       - name: Checkout source repo
         uses: actions/checkout@v4
 


### PR DESCRIPTION
…persistence

- Revert merging of setup-maven-settings into build/deploy jobs
- Separate jobs allow proper cross-job volume mount persistence on same runner
- Keep all Copilot fixes: removed unsafe env vars, scoped secrets, removed testFailureIgnore, added permissions
- Volume mount /home/runner/caches/pentaho/.m2:/root/.m2 now persists correctly across job boundaries