### PR TITLE
fix(ci): restore Maven repository URLs using proper GitHub expressions

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -66,9 +66,19 @@ jobs:
 
     env:
       JFROG_CLI_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      ARTIFACTORY_BASE_URL: ${{ format('https://{0}/artifactory', vars.ARTIFACTORY_HOST) }}
+      RESOLVE_REPO_MIRROR: ${{ format('https://{0}/artifactory/pnt-mvn', vars.ARTIFACTORY_HOST) }}
+      PUBLIC_RELEASE_REPO_URL: ${{ format('https://{0}/artifactory/pntpub-maven-dev', vars.ARTIFACTORY_HOST) }}
+      PRIVATE_RELEASE_REPO: pntprv-maven-dev
+      PRIVATE_RELEASE_REPO_URL: ${{ format('https://{0}/artifactory/pntprv-maven-dev', vars.ARTIFACTORY_HOST) }}
+      PUBLIC_SNAPSHOT_REPO_URL: ${{ format('https://{0}/artifactory/pntpub-maven-snapshot', vars.ARTIFACTORY_HOST) }}
+      PRIVATE_SNAPSHOT_REPO: pntprv-maven-snapshot
+      PRIVATE_SNAPSHOT_REPO_URL: ${{ format('https://{0}/artifactory/pntprv-maven-snapshot', vars.ARTIFACTORY_HOST) }}
       NEXUS_DEPLOY_USER: ${{ secrets.PENTAHO_CICD_ONE_USER }}
       NEXUS_DEPLOY_PASSWORD: ${{ secrets.PENTAHO_CICD_ONE_KEY }}
+      SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
       SONAR_TOKEN: ${{ secrets.WINGMAN_SONAR_TOKEN }}
+      SLACK_CHANNEL: yoda-prs
 
     steps:
       - name: Checkout code
@@ -163,6 +173,9 @@ jobs:
         password: ${{ secrets.PENTAHO_CICD_ONE_KEY }}
       volumes:
         - /home/runner/caches/pentaho/.m2:/root/.m2
+
+    env:
+      ARTIFACTORY_HOST: https://${{ vars.ARTIFACTORY_HOST }}
 
     steps:
       - name: Retrieve settings file

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -68,6 +68,9 @@ jobs:
         - /home/runner/caches/pentaho/.m2:/root/.m2
     
     env:
+      ARTIFACTORY_HOST: https://${{ vars.ARTIFACTORY_HOST }}
+      ARTIFACTORY_BASE_URL: ${{ format('https://{0}/artifactory', vars.ARTIFACTORY_HOST) }}
+      RESOLVE_REPO_MIRROR: ${{ format('https://{0}/artifactory/pnt-mvn', vars.ARTIFACTORY_HOST) }}
       NEXUS_DEPLOY_USER: ${{ secrets.PENTAHO_CICD_ONE_USER }}
       NEXUS_DEPLOY_PASSWORD: ${{ secrets.PENTAHO_CICD_ONE_KEY }}
       SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
       volumes:
         - /home/runner/caches/pentaho/.m2:/root/.m2
 
+    env:
+      ARTIFACTORY_HOST: https://${{ vars.ARTIFACTORY_HOST }}
+
     steps:
       - name: Checkout source repo
         uses: actions/checkout@v4


### PR DESCRIPTION
- Add back essential Maven repository configuration to deploy-release-candidate job
- Use format() function with vars.ARTIFACTORY_HOST instead of broken ${} syntax
- Add ARTIFACTORY_BASE_URL and RESOLVE_REPO_MIRROR with proper GitHub expressions
- Ensures composite actions receive repository URLs for Maven to resolve dependencies
- Honors Copilot's security concerns while maintaining build functionality
- Add minimal env setup to bump-version jobs (pr.yml, merge.yml, release.yml)