### PR TITLE
fix(ci): add missing sonar.projectKey to SonarQube scans

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -147,7 +147,7 @@ jobs:
         continue-on-error: true
         env:
           sonar_utility: sonar-scanner
-          sonar_commands: '("-Dsonar.host.url=${{env.SONAR_HOST_URL}} -Dsonar.token=${{env.SONAR_TOKEN}}")'
+          sonar_commands: '("-Dsonar.projectKey=pentaho:pentaho-connections -Dsonar.host.url=${{env.SONAR_HOST_URL}} -Dsonar.token=${{env.SONAR_TOKEN}}")'
 
       - name: Report notifications
         if: always()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,7 +101,7 @@ jobs:
         uses: lumada-common-services/gh-composite-actions@stable
         env:
           sonar_utility: sonar-scanner
-          sonar_commands: '("-Dsonar.host.url=${{env.SONAR_HOST_URL}} -Dsonar.token=${{env.SONAR_TOKEN}} -Dsonar.pullrequest.key=${{github.event.number}} -Dsonar.pullrequest.branch=${{github.event.pull_request.head.ref}} -Dsonar.pullrequest.base=${{github.event.pull_request.base.ref}}")'
+          sonar_commands: '("-Dsonar.projectKey=pentaho:pentaho-connections -Dsonar.host.url=${{env.SONAR_HOST_URL}} -Dsonar.token=${{env.SONAR_TOKEN}} -Dsonar.pullrequest.key=${{github.event.number}} -Dsonar.pullrequest.branch=${{github.event.pull_request.head.ref}} -Dsonar.pullrequest.base=${{github.event.pull_request.base.ref}}")'
 
       - name: Slack Notification
         if: failure()


### PR DESCRIPTION
- Add sonar.projectKey=pentaho:pentaho-connections to merge.yml scan
- Add sonar.projectKey=pentaho:pentaho-connections to pr.yml scan
- Fixes: 'ERROR: You must define the following mandatory properties for Unknown: sonar.projectKey'
- SonarQube scan will now complete successfully